### PR TITLE
Shutdown if attached game closes

### DIFF
--- a/UnrealVR/MainWindow.xaml.cs
+++ b/UnrealVR/MainWindow.xaml.cs
@@ -360,7 +360,7 @@ namespace UnrealVR {
                     lastFrontendSignal = now;
                 }
             } else {
-                if (m_connected && m_commandLineAttachExe.Length != 0)
+                if (m_connected && !string.IsNullOrEmpty(m_commandLineAttachExe))
                 {
                     // If we launched with an attached game exe, we shut ourselves down once that game closes.
                     Application.Current.Shutdown();


### PR DESCRIPTION
If uevr was launched with the purpose of attaching to a single game, it makes sense to auto-kill uevr if the game closes