### PR TITLE
Adds a mechanism to execute a game and attach to process using launch arguments

### DIFF
--- a/UEVR/App.xaml
+++ b/UEVR/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-             StartupUri="MainWindow.xaml">
+             Startup="Application_Startup">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/UEVR/App.xaml.cs
+++ b/UEVR/App.xaml.cs
@@ -1,17 +1,64 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace UEVR
 {
+    class LaunchArguments
+    {
+        public string Executable { get; set; }
+        public string Arguments { get; set; }
+        public string WorkingDirectory { get; set; }
+        public string ProcessName { get; set; }
+    }
+
     /// <summary>
     /// Interaction logic for App.xaml
     /// </summary>
     public partial class App : Application
     {
+        private static LaunchArguments GetLaunchArguments(string[] args)
+        {
+            Dictionary<string, string> argumentos = new Dictionary<string, string>();
+            var result = new LaunchArguments();
+            foreach (string arg in args)
+            {
+                // Dividir cada argumento en clave y valor
+                string[] argSplitted = arg.Split('=');
+                if (argSplitted.Length == 2)
+                {
+                    var parameter = argSplitted[0].Trim();
+                    var value = argSplitted[1].Trim();
+
+                    var property = result.GetType().GetProperty(parameter);
+                    if (property != null)
+                    {
+                        property.SetValue(result, value, null);
+                    }
+                    else
+                    {
+                        throw new NotImplementedException($"Parameter '{parameter}' not found");
+                    }
+                }
+                else
+                {
+                    throw new NotImplementedException($"Argument '{arg}' without the expected format");
+                }
+            }
+
+            return result;
+        }
+
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            MainWindow wnd = new();
+            wnd.Show();
+
+            var arguments = GetLaunchArguments(e.Args);
+            if (arguments != null)
+            {
+                wnd.AttachToProcess(arguments);
+            }
+        }
     }
 }

--- a/UEVR/App.xaml.cs
+++ b/UEVR/App.xaml.cs
@@ -4,7 +4,10 @@ using System.Windows;
 
 namespace UEVR
 {
-    class LaunchArguments
+    /// <summary>
+    /// Parsed executable arguments to use executing any game process 
+    /// </summary>
+    internal class AppArguments
     {
         public string Executable { get; set; }
         public string Arguments { get; set; }
@@ -17,10 +20,13 @@ namespace UEVR
     /// </summary>
     public partial class App : Application
     {
-        private static LaunchArguments GetLaunchArguments(string[] args)
+        private static AppArguments GetAppArguments(string[] args)
         {
-            Dictionary<string, string> argumentos = new Dictionary<string, string>();
-            var result = new LaunchArguments();
+            if (args.Length == 0) {
+                return null;
+            }
+
+            var result = new AppArguments();
             foreach (string arg in args)
             {
                 // Dividir cada argumento en clave y valor
@@ -54,7 +60,7 @@ namespace UEVR
             MainWindow wnd = new();
             wnd.Show();
 
-            var arguments = GetLaunchArguments(e.Args);
+            var arguments = GetAppArguments(e.Args);
             if (arguments != null)
             {
                 wnd.AttachToProcess(arguments);

--- a/UEVR/MainWindow.xaml.cs
+++ b/UEVR/MainWindow.xaml.cs
@@ -1167,7 +1167,7 @@ namespace UEVR {
 
         bool skipAlertMessages = false;
 
-        internal void AttachToProcess(LaunchArguments arguments) {
+        internal void AttachToProcess(AppArguments arguments) {
             var executableDirectory = System.IO.Path.GetDirectoryName(arguments.Executable);
 
             skipAlertMessages = true;


### PR DESCRIPTION
Adds a mechanism to run the frontend using arguments. This brings new possibilities to other for other tools to interact with UEVR.
Using the arguments it's possible to run execute any game after launch and attach automatically to it:

Example:

UEVRInjector.exe Executable="C:\test\RoboCop.exe" Arguments="-x -r" ProcessName="RoboCop-Win64-Shipping"


