### PR TITLE
Add option to focus game window on injection

### DIFF
--- a/UEVR/MainWindow.xaml
+++ b/UEVR/MainWindow.xaml
@@ -158,6 +158,10 @@
                                     <ToggleButton x:Name="m_nullifyVRPluginsCheckbox" HorizontalAlignment="Left"/>
                                     <TextBlock TextWrapping="Wrap" Text="Nullify VR Plugins"/>
                                 </StackPanel>
+                                <StackPanel Orientation="Horizontal">
+                                    <ToggleButton x:Name="m_focusGameOnInjectionCheckbox" HorizontalAlignment="Left" IsChecked="True"/>
+                                    <TextBlock TextWrapping="Wrap" Text="Focus game on injection"/>
+                                </StackPanel>
                             </StackPanel>
                             <TextBlock x:Name="m_connectionStatus" TextWrapping="Wrap" Text="Unknown status"/>
                         </StackPanel>

--- a/UEVR/MainWindow.xaml.cs
+++ b/UEVR/MainWindow.xaml.cs
@@ -150,6 +150,7 @@ namespace UEVR {
             }
         }
     }
+
     public partial class MainWindow : Window {
         // variables
         // process list
@@ -172,6 +173,9 @@ namespace UEVR {
         private ExecutableFilter m_executableFilter = new ExecutableFilter();
         private string? m_commandLineAttachExe = null;
         private bool m_ignoreFutureVDWarnings = false;
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        public static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);
 
         public MainWindow() {
             InitializeComponent();
@@ -204,6 +208,7 @@ namespace UEVR {
             m_openxrRadio.IsChecked = m_mainWindowSettings.OpenXRRadio;
             m_nullifyVRPluginsCheckbox.IsChecked = m_mainWindowSettings.NullifyVRPluginsCheckbox;
             m_ignoreFutureVDWarnings = m_mainWindowSettings.IgnoreFutureVDWarnings;
+            m_focusGameOnInjectionCheckbox.IsChecked = m_mainWindowSettings.FocusGameOnInjection;
 
             m_updateTimer.Tick += (sender, e) => Dispatcher.Invoke(MainWindow_Update);
             m_updateTimer.Start();
@@ -351,6 +356,10 @@ namespace UEVR {
                     m_lastAutoInjectTime = now;
                     m_commandLineAttachExe = null; // no need anymore.
                     FillProcessList();
+                    if (m_focusGameOnInjectionCheckbox.IsChecked == true)
+                    {
+                        SwitchToThisWindow(process.MainWindowHandle, true);
+                    }
                 }
             }
         }
@@ -574,6 +583,7 @@ namespace UEVR {
             m_mainWindowSettings.OpenVRRadio = m_openvrRadio.IsChecked == true;
             m_mainWindowSettings.NullifyVRPluginsCheckbox = m_nullifyVRPluginsCheckbox.IsChecked == true;
             m_mainWindowSettings.IgnoreFutureVDWarnings = m_ignoreFutureVDWarnings;
+            m_mainWindowSettings.FocusGameOnInjection = m_focusGameOnInjectionCheckbox.IsChecked == true;
 
             m_mainWindowSettings.Save();
         }
@@ -1039,6 +1049,11 @@ namespace UEVR {
                 }
 
                 Injector.InjectDll(process.Id, "UEVRBackend.dll");
+            }
+
+            if (m_focusGameOnInjectionCheckbox.IsChecked == true)
+            {
+                SwitchToThisWindow(process.MainWindowHandle, true);
             }
         }
 

--- a/UEVR/MainWindowSettings.cs
+++ b/UEVR/MainWindowSettings.cs
@@ -34,5 +34,13 @@ namespace UEVR {
             get { return (bool)this["IgnoreFutureVDWarnings"]; }
             set { this["IgnoreFutureVDWarnings"] = value; }
         }
+
+        [UserScopedSettingAttribute()]
+        [DefaultSettingValueAttribute("true")]
+        public bool FocusGameOnInjection
+        {
+            get { return (bool)this["FocusGameOnInjection"]; }
+            set { this["FocusGameOnInjection"] = value; }
+        }
     }
 }


### PR DESCRIPTION
Some games don't play audio or render at reduced frame rate when their window is not in focus. Switching active window when VR session is started is a hassle. 

This is especially true in Virtual Desktop (put gamepad down, pickup VR controller, long press menu, select switch to desktop, pick window, open menu, select switch to VR).

This commit adds an option to automatically focus game window post injection making UEVR experience more streamlined.