### PR TITLE
Implement launcher integration

### DIFF
--- a/UEVR/MainWindow.xaml.cs
+++ b/UEVR/MainWindow.xaml.cs
@@ -173,6 +173,7 @@ namespace UEVR {
         private ExecutableFilter m_executableFilter = new ExecutableFilter();
         private string? m_commandLineAttachExe = null;
         private string? m_commandLineLaunchExe = null;
+        private string? m_commandLineLaunchArgs = null;
         private int m_commandLineDelayInjection = 0;
         private bool m_ignoreFutureVDWarnings = false;
 
@@ -193,6 +194,10 @@ namespace UEVR {
                 }
                 if (arg.StartsWith("--launch=")) {
                     m_commandLineLaunchExe = arg.Substring(arg.IndexOf('=') + 1); // game exe URI may contain any characters including '='
+                    continue;
+                }
+                if (arg.StartsWith("--launch_args=")) {
+                    m_commandLineLaunchArgs = arg.Substring(arg.IndexOf('=') + 1); // space separated list of game exe arguments
                     continue;
                 }
                 if (arg.StartsWith("--delay=")) {
@@ -284,7 +289,8 @@ namespace UEVR {
                 try {
                     Process.Start(new ProcessStartInfo {
                         FileName = m_commandLineLaunchExe,
-                        UseShellExecute = true // for launcher compatiblity, executable might be an URI
+                        UseShellExecute = true, // for launcher compatiblity, executable might be an URI
+                        Arguments = m_commandLineLaunchArgs
                     });
 
                     m_launchExeDone = true;


### PR DESCRIPTION
Proposed change allows UEVR frontend to be in charge how game is launched an injected while other tool like Rai Pal tells it what to launch. This in turn enables one click 'launch to VR' flow.

For that end 3 new command line options are added:
* `--launch=<game.exe or launcher URI>` to specify game to launch
* `--launch_args=<space separated list of game.exe arguments>` optional, mainly for Gog Galaxy integration
* `--delay=<number of seconds>` to wait before injection for games that have problems with injecting right away

Summary example (put this into Windows shortcut):
```
UEVRInjector.exe "--launch=com.epicgames.launcher://apps/da36711940d4460da57d8d6ad67236a4%3Aa1afcdb1d2344232954be97d4b86b9a8%3Acfbbc006f3ee4ba0bfff3ffa46942f90?action=launch" --attach=CosmicShake-Win64-Shipping --delay=30
```

This will automatically:
1. start SpongeBob Cosmic Shake on EGS.
2. upon detection of game process wait 30s for the player to get into the game
3. inject and refocus game window

From user perspective all he/she does is to click the shortcut and magic will happen.

Alternatively launcher like Rai Pal can invoke options above.