### PR TITLE
capability of ignoring unwanted processes in injection list

### DIFF
--- a/UEVR/MainWindow.xaml.cs
+++ b/UEVR/MainWindow.xaml.cs
@@ -177,6 +177,8 @@ namespace UEVR {
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         public static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);
 
+        private string excludedProcessesFile = "excluded.txt";
+
         public MainWindow() {
             InitializeComponent();
 
@@ -1068,6 +1070,20 @@ namespace UEVR {
         private static extern bool IsWow64Process([In] IntPtr hProcess, [Out] out bool wow64Process);
 
         private bool IsInjectableProcess(Process process) {
+
+            List<string> excludedProcesses = new List<string>();
+
+            // Check if the excluded processes file exists
+            if (File.Exists(excludedProcessesFile)) {
+                // Read excluded process names from the text file
+                excludedProcesses = File.ReadAllLines(excludedProcessesFile).ToList();
+            }
+        
+            // Check if the process name is in the excluded list
+            if (excludedProcesses.Contains(process.ProcessName)) {
+                return false;
+            }
+            
             try {
                 if (Environment.Is64BitOperatingSystem) {
                     try {

--- a/UEVR/MainWindow.xaml.cs
+++ b/UEVR/MainWindow.xaml.cs
@@ -1070,20 +1070,7 @@ namespace UEVR {
         private static extern bool IsWow64Process([In] IntPtr hProcess, [Out] out bool wow64Process);
 
         private bool IsInjectableProcess(Process process) {
-
-            List<string> excludedProcesses = new List<string>();
-
-            // Check if the excluded processes file exists
-            if (File.Exists(excludedProcessesFile)) {
-                // Read excluded process names from the text file
-                excludedProcesses = File.ReadAllLines(excludedProcessesFile).ToList();
-            }
         
-            // Check if the process name is in the excluded list
-            if (excludedProcesses.Contains(process.ProcessName)) {
-                return false;
-            }
-            
             try {
                 if (Environment.Is64BitOperatingSystem) {
                     try {
@@ -1118,6 +1105,21 @@ namespace UEVR {
                     if (moduleLow == "d3d11.dll" || moduleLow == "d3d12.dll") {
                         return true ;
                     }
+                }
+
+                // Check if the excluded processes file exists
+                if (File.Exists(excludedProcessesFile)) {
+                    
+                    List<string> excludedProcesses = new List<string>();
+    
+                    // Read excluded process names from the text file
+                    excludedProcesses = File.ReadAllLines(excludedProcessesFile).ToList();
+    
+                    // Check if the process name is in the excluded list
+                    if (excludedProcesses.Contains(process.ProcessName)) {
+                        return false;
+                    }
+                    
                 }
 
                 return false;


### PR DESCRIPTION
Made so the user can write an "excluded.txt" file that includes processes uevr will ignore in the injection list, possibly solves #12 and this specific issue I was having where UEVR always put parsec on the list of injectable processes when it definitely isn't one

the code added is very simple and should only trigger in case the txt file is actually written

![image](https://github.com/praydog/uevr-frontend/assets/54243954/ae881410-e7bd-418d-b0df-c0596c339c6a)
