### PR TITLE
Remove existing profile on import

### DIFF
--- a/UEVR/MainWindow.xaml.cs
+++ b/UEVR/MainWindow.xaml.cs
@@ -527,9 +527,12 @@ namespace UEVR {
             var gameGlobalDir = globalDir + "\\" + gameName;
 
             try {
+                if(Directory.Exists(gameGlobalDir)) {
+                    Directory.Delete(gameGlobalDir, true);
+                }
                 if (!Directory.Exists(gameGlobalDir)) {
                     Directory.CreateDirectory(gameGlobalDir);
-                }
+                } 
 
                 bool wantsExtract = true;
 


### PR DESCRIPTION
As modders update their profiles, users import the updated profile but it currently just merges the files leaving old objecthooks and other files. The result is that the imported profile doesn't work and the users have to manually load global dir and delete the old first. Not only does this negate the functionality of using the import button, but also many users don't know how to do this.

This patch checks for the presence of the existing folder and deletes it first allowing each import to work freshly as expected.